### PR TITLE
Castform case 6

### DIFF
--- a/src/battle_system.c
+++ b/src/battle_system.c
@@ -1378,8 +1378,8 @@ u8 ability_battle_effects(u8 switch_id, u8 bank, u8 ability_to_check, u8 special
 		if(battle_participants[bank].ability_id==ABILITY_FORECAST && has_ability_effect(bank,0,1))
 		{
 			effect = prepare_castform_change(castform_change, bank);
-			if (effect == true) //very important, don't confuse '=' with '=='!
-                            break; //tip (effect == true) can be substituted to if (effect)
+			if (effect == true)
+                            break;
 		}
 	}
     break;

--- a/src/battle_system.c
+++ b/src/battle_system.c
@@ -1373,9 +1373,16 @@ u8 ability_battle_effects(u8 switch_id, u8 bank, u8 ability_to_check, u8 special
         }
         break;
     case 6: //check castform and cherrim
-        {
-            break;
-        }
+        	for (u8 i = 0; i < no_of_all_banks; i++)
+	{
+		if(battle_participants[bank].ability_id==ABILITY_FORECAST && has_ability_effect(bank,0,1))
+		{
+			effect = prepare_castform_change(castform_change, bank);
+			if (effect == true) //very important, don't confuse '=' with '=='!
+                            break; //tip (effect == true) can be substituted to if (effect)
+		}
+	}
+    break;
     case 7: //user's synchronize
         adder=0x40;
     case 8: //target's synchronize after static etc.

--- a/src/bs_start_attack.c
+++ b/src/bs_start_attack.c
@@ -6,6 +6,7 @@
 #include "new_battle_struct.h"
 #include "static_references.h"
 
+u8 weather_abilities_effect();
 u8 check_mega_condition(u8 bank);
 u8 find_move_in_table(u16 move, u16 table_ptr[]);
 


### PR DESCRIPTION
With considerable handholding from Dizzy, we were able to write Castform's Forecast case over and test it. With these changes, Castform transforms appropriately. With the addition to bs_start_attack.c, Weather Ball also does not change type in Air Lock or Cloud Nine, but does still switch to the active weather's animation. I will make an issue about it.