### PR TITLE
Update Case 6 with Cherrim

### DIFF
--- a/src/battle_system.c
+++ b/src/battle_system.c
@@ -1374,6 +1374,26 @@ u8 ability_battle_effects(u8 switch_id, u8 bank, u8 ability_to_check, u8 special
         break;
     case 6: //check castform and cherrim
         {
+            for (u8 i = 0; i < no_of_all_banks; i++)
+            {
+                if(battle_participants[i].ability_id==ABILITY_FORECAST && has_ability_effect(i,0,1))
+                {
+                    effect = prepare_castform_switch(castform_switch(i), i);
+                    if (effect == true)
+                        break;
+                }
+                else if(battle_participants[i].ability_id==ABILITY_FLOWER_GIFT && has_ability_effect(i,0,1))
+                {
+                    effect = should_cherrim_change(i);
+                    if (effect)
+                    {
+                      execute_battle_script(&cherrimswitch_bs);
+                      battle_scripting.active_bank = i;
+                      battle_stuff_ptr.ptr->castform_switch_form = effect - 1;
+                      break;
+                    }
+                }
+            }
             break;
         }
     case 7: //user's synchronize


### PR DESCRIPTION
Changed all mentions of "bank" to "i" in Castform's check, and added Cherrim's check. Cherrim's check appears to work properly ingame, though there is an issue with Cherrim being stuck in its Sunshine form if its ability is changed. Cherrim's spritesheet needs to be set up like Castform's or the switch between Sunshine and Overcast forms may call the wrong sprite/palette.