### PR TITLE
Update battlescripts_for_moves.s to fix stockpile

### DIFF
--- a/src/battlescripts_for_moves.s
+++ b/src/battlescripts_for_moves.s
@@ -805,12 +805,12 @@ SPIT_UP:
 	attackcanceler
 	attackstring
 	ppreduce
-	stockpiletobasedamage 0x82D9F94
 	accuracycheck SPITUP_FAIL 0x0
 	jumpiftypenotaffected SPITUP_FAIL
 	critcalc
 	damagecalc
 	damageadjustment
+	stockpiletobasedamage 0x82D9F94
 	attackanimation
 	waitanimation
 	effectiveness_sound


### PR DESCRIPTION
I'm not sure how much reordering will break.
stockpiletobasedamage resets the value for the stockpile counter, and the formula for damagecalc multiplies by the stockpile counter, and so before this fix it would wind up giving zero damage every time